### PR TITLE
Fixed compilation with modern GCC

### DIFF
--- a/include/kognac/progargs.h
+++ b/include/kognac/progargs.h
@@ -7,6 +7,7 @@
 #include <vector>
 #include <set>
 #include <map>
+#include <memory>
 
 using namespace std;
 


### PR DESCRIPTION
Added required #include <memory> to let kognac compile on more recent GCC versions.