### PR TITLE
Fix for naming conflict with DuckDB on block size

### DIFF
--- a/include/kognac/consts.h
+++ b/include/kognac/consts.h
@@ -54,7 +54,7 @@
 #define MAX_TERM_SIZE 16384
 
 //Used in the compressed file
-#define BLOCK_SIZE 65536
+#define KOGNAC_BLOCK_SIZE 65536
 #define BLOCK_MIN_SIZE 16
 
 #define BLOCK_SUPPORT_BUFFER_COMPR 64000000

--- a/include/kognac/consts.h
+++ b/include/kognac/consts.h
@@ -53,10 +53,6 @@
 
 #define MAX_TERM_SIZE 16384
 
-//Used in the compressed file
-#define KOGNAC_BLOCK_SIZE 65536
-#define BLOCK_MIN_SIZE 16
-
 #define BLOCK_SUPPORT_BUFFER_COMPR 64000000
 #define MIN_MEM_SORT_TRIPLES 128000000
 

--- a/include/kognac/consts.h
+++ b/include/kognac/consts.h
@@ -53,6 +53,7 @@
 
 #define MAX_TERM_SIZE 16384
 
+//Used in the compressed file
 #define BLOCK_SUPPORT_BUFFER_COMPR 64000000
 #define MIN_MEM_SORT_TRIPLES 128000000
 


### PR DESCRIPTION
This will allow Trident to use DuckDBs engine as an alternative for storing some graphs.